### PR TITLE
Content changes

### DIFF
--- a/app/views/notifications/email.html
+++ b/app/views/notifications/email.html
@@ -23,7 +23,11 @@ Email
     </p>
 
     <p class="govuk-body">
-      We've updated the prisoner money intelligence tool. Now you can search for, identify and monitor transactions in one or many prisons, and also, among many other things, be notified if:
+      We've updated the prisoner money intelligence tool.
+    </p>
+
+    <p class="govuk-body">
+      At the moment, you can search for, identify and monitor transactions in one or many prisons. But we’ve added features so you can look at more specific transactions, for example, when:
     </p>
 
     {# Remove 'govuk-list--bullet' class for standard list #}
@@ -48,8 +52,6 @@ Email
       html: 'Set up notifications'
     }) }}
     </form>
-
-    <p class="govuk-body">We hope you find the new features useful. Any <a href="https://send-money-to-prisoner.service.gov.uk/en-gb/contact-us/">feedback</a> really helps us improve the tool further.</p>
 
     <p class="govuk-body">
       Kind regards,<br>

--- a/app/views/notifications/index.html
+++ b/app/views/notifications/index.html
@@ -51,7 +51,7 @@ Manage email notifications - Prisoner money intelligence
         items: [
           {
             value: "creditsOrDisbursementsThatAreNotAWholeNumber",
-            text: "Not a whole number, eg £25.19",
+            text: "Not a whole number, for example, £25.19",
             checked: checked("amounts", "creditsOrDisbursementsThatAreNotAWholeNumber")
           },
           {

--- a/app/views/notifications/index.html
+++ b/app/views/notifications/index.html
@@ -33,7 +33,7 @@ Manage email notifications - Prisoner money intelligence
         items: [
           {
             value: "allTransactions",
-            text: "All transactions you’re already following - prisoners, debit cards, bank accounts"
+            text: "All transactions you’re already following - prisoners, debit cards, bank accounts - in your prisons"
           }
         ]
       }) }}
@@ -151,7 +151,7 @@ Manage email notifications - Prisoner money intelligence
           },
           {
             value: "onceAMonth",
-            text: "No, I can check the notifications page"
+            text: "No, I can check the notifications screen"
           }
         ]
       }) }}

--- a/app/views/notifications/notifications-page.html
+++ b/app/views/notifications/notifications-page.html
@@ -9,74 +9,11 @@ GOV.UK Prototype Kit
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
-      Notifications
+      Check your notifications
     </h1>
   </div>
 </div>
-<!-- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body"><a href="#">Edit notifications</a></p>
-  </div>
 
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-body" style="float:right;"><a href="#">Print</a> <a href="#">Export</a></p>
-  </div>
-</div> -->
-<!-- <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-body govuk-!-margin-top-0"> -->
-<!-- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <ul class="govuk-list">
-      <li>12/10/2018</li>
-      <li class="govuk-!-font-weight-bold">£35.17 credit</li>
-      <li>Card ending 9876 (“Mick Myers”) to <a href="#">Adam Douglas</a> (A1619FY)</li>
-      <li class="govuk-inset-text govuk-!-margin-top-0">Card is on monitored list</li>
-    </ul>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-body" style="float:right;"><a href="#">View</a></p>
-  </div>
-</div> -->
-<!-- <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-body govuk-!-margin-top-0"> -->
-<!-- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <ul class="govuk-list">
-      <li>12/10/2018</li>
-      <li class="govuk-!-font-weight-bold">£35.17 credit</li>
-      <li>Card ending 9876 (“Mick Myers”) to <a href="#">Adam Douglas</a> (A1619FY)</li>
-    </ul>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-body" style="float:right;"><a href="#">View</a></p>
-  </div>
-</div> -->
-<!-- <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-body govuk-!-margin-top-0"> -->
-<!-- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <ul class="govuk-list">
-      <li>12/10/2018</li>
-      <li class="govuk-!-font-weight-bold">£35.17 credit</li>
-      <li>Card ending 9876 (“Mick Myers”) to <a href="#">Adam Douglas</a> (A1619FY)</li>
-    </ul>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-body" style="float:right;"><a href="#">View</a></p>
-  </div>
-</div> -->
-<!-- <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-body govuk-!-margin-top-0"> -->
-<!-- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <ul class="govuk-list">
-      <li>12/10/2018</li>
-      <li class="govuk-!-font-weight-bold">£35.17 credit</li>
-      <li>Card ending 9876 (“Mick Myers”) to <a href="#">Adam Douglas</a> (A1619FY)</li>
-    </ul>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-body" style="float:right;"><a href="#">View</a></p>
-  </div>
-</div> -->
-
-<!-- <hr class="govuk-section-break govuk-section-break--m  govuk-body govuk-!-margin-top-0">-->
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <dl class="app-check-your-answers app-check-your-answers--short govuk-!-margin-bottom-4" style="padding: 10px; background-color: #dee0e2; width: 98%;">


### PR DESCRIPTION
# This PR has the following content changes

**In the email**
Dear [intelligence tool user],
We've updated the prisoner money intelligence tool.  (all fine)
At the moment, you can search for, identify and monitor transactions in one or many prisons. But we’ve added features so you can look at more specific transactions, for example, when: (bullet points)

Also in the email
Remove the feedback line at the end of the email - ‘Any feedback really helps etc..’

**In the notifications tickbox page**
Under ‘Monitored transactions’

Add ‘in your prisons’ to the end of the line so it reads:
‘All transactions you’re already following - prisoners, debit cards, bank accounts - in your prisons’

Also in the notifications tickbox page
Bottom line, radio button should read :
‘No, I can check the notifications screen’
(ie screen, not page)

**Confirmation page**
The line ‘You can edit your notification settings at any time’
Has this link been set up in the proto?

**Notifications page**
This heading should read ‘Check your notifications’ 
This is to match other design and it’s a more active headline
