### PR TITLE
MTP-753 Content changes to the email

### DIFF
--- a/app/views/notifications/email.html
+++ b/app/views/notifications/email.html
@@ -14,12 +14,12 @@ Email
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h1 class="govuk-heading-l">
-      New notification features added to intelligence tool...
+      New notifications feature added to intelligence tool...
     </h1>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <p class="govuk-body">
-      Dear [intelligence tool user],
+      Dear Jason,
     </p>
 
     <p class="govuk-body">
@@ -27,7 +27,7 @@ Email
     </p>
 
     <p class="govuk-body">
-      At the moment, you can search for, identify and monitor transactions in one or many prisons. But we’ve added features so you can look at more specific transactions, for example, when:
+      At the moment, you can search for, identify and monitor transactions in one or many prisons. But we’ve added a notifications feature so you can look at more specific transactions, for example, when:
     </p>
 
     {# Remove 'govuk-list--bullet' class for standard list #}


### PR DESCRIPTION
The heading now reads:

New notification‌s feature added to intelligence tool...

And in the body of the email:

'But we’ve added a notifications feature so you can look at more specific transactions, for example, when: etc etc'

**Screenshot**
![image](https://user-images.githubusercontent.com/868772/49872284-89d26900-fe10-11e8-9b68-b18f2ad762b6.png)
